### PR TITLE
Feature 6408: Don't raise errors on invalid logins

### DIFF
--- a/lib/devise_ldap_authenticatable/model.rb
+++ b/lib/devise_ldap_authenticatable/model.rb
@@ -110,7 +110,7 @@ module Devise
 
           if ::Devise.ldap_create_user && resource.new_record? && resource.valid_ldap_authentication?(attributes[:password])
             resource.ldap_before_save if resource.respond_to?(:ldap_before_save)
-            resource.save!
+            resource.save
           end
 
           resource


### PR DESCRIPTION
Fix voor [6408 Excepties die worden gegooid bij validatiefouten](http://redmine.cg.lan/issues/6408)

> Wanneer iemand op recharge in wil loggen maar de validatie faalt (wachtwoord te kort; ongeldig email adres; etc), dan veroorzaakt dat een onafgevangen exceptie. Het probleem is te reproduceren door naar https://www.recharge.com/fr-FR/login te gaan en dan een willekeurig email adres en wachtwoord van 1 teken in te vullen.
>
> De excepties die hieruit komen zijn hier te vinden.
>
> https://sentry.io/cg-services-bv/rechargecom/issues/230373647/
>
> Het is uiteraard niet de bedoeling dat dit een 500/exceptie veroorzaakt. Wat we willen is dat de klant een foutlmelding krijgt als 'ongeldige gebruikersnaam en/of wachtwoord.

# Probleem uitleg

Bij Recharge.com wordt een error gegooid als je probeert in te loggen met een email adres dat niet bekend is in LDAP en een wachtwoord dat minder tekens heeft dan hetgeen dat devise als minimum stelt (`config.password_length`).

Dit komt door de `resource.save!` callback die in de Devise gem valideert of de user geldig is. Omdat het wachtwoord te kort is, faalt die validatie en zal dat als error naar boven komen. Als we het uitroepteken weghalen `resource.save`, dan zal het toevoegen van die user stil falen.

## Extra vraag

Een extra vraag die bij opkomt is of we ieder email adres dat niet bij ons bekend is, en dat met wachtwoord wordt ingevoerd, willen opslaan in LDAP?

### Reproduceren

1. Ga naar het inlogscherm op recharge.com
2. Vul bij het inloggen een email adres in dat niet bekend is in de database.
3. Vul een wachtwoord in van minimaal 6 tekens.
4. Klik log in.
5. Je krijgt nu een bevestiging email. Wanneer je deze bevestigt kun je met het opgegeven email adres en wachtwoord gewoon inloggen.