### PR TITLE
Fix CVE-2017-17718

### DIFF
--- a/devise_ldap_authenticatable.gemspec
+++ b/devise_ldap_authenticatable.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency('devise', '>= 3.4.1')
-  s.add_dependency('net-ldap', '>= 0.6.0', '<= 0.11')
+  s.add_dependency('net-ldap', '>= 0.16.0')
 
   s.add_development_dependency('rake', '>= 0.9')
   s.add_development_dependency('rdoc', '>= 3')

--- a/lib/devise_ldap_authenticatable/ldap/connection.rb
+++ b/lib/devise_ldap_authenticatable/ldap/connection.rb
@@ -233,7 +233,6 @@ module Devise
       end
 
       def change_password!
-        binding.pry
         update_ldap(:userpassword => Net::LDAP::Password.generate(:ssha, @new_password))
       end
 


### PR DESCRIPTION
The Net::LDAP (aka net-ldap) gem before 0.16.0 
for Ruby has Missing SSL Certificate Validation.

Also see: https://github.com/cschiewek/devise_ldap_authenticatable/pull/243